### PR TITLE
feat: implement Reconcile - ability to change upstream list on the fly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-09-01T20:34:11Z by kres ee90a80-dirty.
+# Generated on 2020-09-09T15:36:30Z by kres 7e146df-dirty.
 
 # common variables
 
@@ -34,7 +34,7 @@ COMMON_ARGS += --build-arg=USERNAME=$(USERNAME)
 COMMON_ARGS += --build-arg=TOOLCHAIN=$(TOOLCHAIN)
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION=$(GOFUMPT_VERSION)
 COMMON_ARGS += --build-arg=TESTPKGS=$(TESTPKGS)
-TOOLCHAIN ?= docker.io/golang:1.14-alpine
+TOOLCHAIN ?= docker.io/golang:1.15-alpine
 
 # help menu
 

--- a/hack/git-chglog/config.yaml
+++ b/hack/git-chglog/config.yaml
@@ -1,12 +1,12 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-09-01T20:34:11Z by kres ee90a80-dirty.
+# Generated on 2020-09-09T15:36:30Z by kres 7e146df-dirty.
 
 style: github
 template: CHANGELOG.tpl.md
 info:
   title: CHANGELOG
-  repository_url: https://github.com/talos-systems/talos
+  repository_url: https://github.com/talos-systems/go-loadbalancer
 options:
   commits:
     # filters:

--- a/loadbalancer/loadbalancer_test.go
+++ b/loadbalancer/loadbalancer_test.go
@@ -72,6 +72,102 @@ type TCPSuite struct {
 	suite.Suite
 }
 
+func (suite *TCPSuite) TestReconcile() {
+	const (
+		upstreamCount = 5
+		pivot         = 2
+	)
+
+	upstreams := make([]mockUpstream, upstreamCount)
+	for i := range upstreams {
+		upstreams[i].identity = strconv.Itoa(i)
+		suite.Require().NoError(upstreams[i].Start())
+	}
+
+	upstreamAddrs := make([]string, len(upstreams))
+	for i := range upstreamAddrs {
+		upstreamAddrs[i] = upstreams[i].addr
+	}
+
+	listenAddr, err := findListenAddress()
+	suite.Require().NoError(err)
+
+	lb := &loadbalancer.TCP{}
+	suite.Require().NoError(lb.AddRoute(
+		listenAddr,
+		upstreamAddrs[:pivot],
+		upstream.WithLowHighScores(-3, 3),
+		upstream.WithInitialScore(1),
+		upstream.WithScoreDeltas(-1, 1),
+		upstream.WithHealthcheckInterval(time.Second),
+		upstream.WithHealthcheckTimeout(100*time.Millisecond),
+	))
+
+	suite.Require().NoError(lb.Start())
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		lb.Wait() //nolint: errcheck
+	}()
+
+	for i := 0; i < 5*pivot; i++ {
+		c, err := net.Dial("tcp", listenAddr)
+		suite.Require().NoError(err)
+
+		id, err := ioutil.ReadAll(c)
+		suite.Require().NoError(err)
+
+		// load balancer should go round-robin across all the upstreams [0:pivot]
+		suite.Assert().Equal([]byte(strconv.Itoa(i%pivot)), id)
+
+		suite.Require().NoError(c.Close())
+	}
+
+	// reconcile the list
+	suite.Require().NoError(lb.ReconcileRoute(listenAddr, upstreamAddrs[pivot:]))
+
+	// bring down pre-pivot upstreams
+	for i := 0; i < pivot; i++ {
+		upstreams[i].Close()
+	}
+
+	upstreamsUsed := map[int64]int{}
+
+	for i := 0; i < 10*(upstreamCount-pivot); i++ {
+		c, err := net.Dial("tcp", listenAddr)
+		suite.Require().NoError(err)
+
+		id, err := ioutil.ReadAll(c)
+		suite.Require().NoError(err)
+
+		// load balancer should go round-robin across all the upstreams [pivot:]
+		no, err := strconv.ParseInt(string(id), 10, 32)
+		suite.Require().NoError(err)
+
+		suite.Assert().Less(no, int64(upstreamCount))
+		suite.Assert().GreaterOrEqual(no, int64(pivot))
+		upstreamsUsed[no]++
+
+		suite.Require().NoError(c.Close())
+	}
+
+	for _, count := range upstreamsUsed {
+		suite.Assert().Equal(10, count)
+	}
+
+	suite.Require().NoError(lb.Close())
+	wg.Wait()
+
+	for i := range upstreams {
+		upstreams[i].Close()
+	}
+}
+
 func (suite *TCPSuite) TestBalancer() {
 	const (
 		upstreamCount   = 5


### PR DESCRIPTION
This is going to be used in Sfyra to provide dynamic load balancer for
the control plane.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>