### PR TITLE
feat: provide a way to configure logger for the loadbalancer

### DIFF
--- a/loadbalancer/loadbalancer_test.go
+++ b/loadbalancer/loadbalancer_test.go
@@ -149,6 +149,8 @@ func (suite *TCPSuite) TestReconcile() {
 		no, err := strconv.ParseInt(string(id), 10, 32)
 		suite.Require().NoError(err)
 
+		suite.Assert().EqualValues(no, pivot+(i+pivot)%(upstreamCount-pivot))
+
 		suite.Assert().Less(no, int64(upstreamCount))
 		suite.Assert().GreaterOrEqual(no, int64(pivot))
 		upstreamsUsed[no]++

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -184,7 +184,13 @@ func (list *List) Reconcile(upstreams []Backend) {
 		i--
 	}
 
-	for upstream := range newUpstreams {
+	// make insert order predictable by going over the list once again,
+	// as iterating over the map might lead to unpredictable order
+	for _, upstream := range upstreams {
+		if _, ok := newUpstreams[upstream]; !ok {
+			continue
+		}
+
 		list.nodes = append(list.nodes, node{
 			backend: upstream,
 			score:   list.initialScore,


### PR DESCRIPTION
It was using `log.Printf` by default which was spamming stdout in Sfyra.

Default is still to use same writer as `log` defaults.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>