### PR TITLE
chore: fix logging and tests

### DIFF
--- a/controlplane/controlplane.go
+++ b/controlplane/controlplane.go
@@ -118,7 +118,7 @@ func (lb *LoadBalancer) Start(upstreamCh <-chan []string) error {
 			select {
 			case upstreams := <-upstreamCh:
 				if err := lb.lb.ReconcileRoute(lb.endpoint, upstreams); err != nil {
-					lb.lb.Logger.Info("failed reconciling list of upstreams",
+					lb.lb.Logger.Warn("failed reconciling list of upstreams",
 						zap.Strings("upstreams", upstreams),
 						zap.Error(err),
 					)

--- a/loadbalancer/node.go
+++ b/loadbalancer/node.go
@@ -31,7 +31,7 @@ func (upstream node) healthCheck(ctx context.Context) error {
 
 	c, err := d.DialContext(ctx, "tcp", upstream.address)
 	if err != nil {
-		upstream.logger.Info("healthcheck failed", zap.String("address", upstream.address), zap.Error(err))
+		upstream.logger.Warn("healthcheck failed", zap.String("address", upstream.address), zap.Error(err))
 
 		return err
 	}


### PR DESCRIPTION
- Replace `.Info` calls with `.Warn`
- Log closing/write errors in tests.
- TestLoadBalancer now starts with negative score - that ensure that we also test backend tiers.