### PR TITLE
feat: add jitter and initial health check wait support to upstreams

### DIFF
--- a/upstream/upstream_test.go
+++ b/upstream/upstream_test.go
@@ -48,6 +48,11 @@ func (suite *ListSuite) TestEmpty() {
 
 	defer l.Shutdown()
 
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	suite.Require().NoError(l.WaitForInitialHealthcheck(ctx), "initial healthcheck should be done immediately")
+
 	backend, err := l.Pick()
 	suite.Assert().Zero(backend)
 	suite.Assert().EqualError(err, "no upstreams available")


### PR DESCRIPTION
Add two features:
- Support for health check jitter: if we start many loadbalancers at once, they might do all of their healthchecks at the same time. Jitter helps us avoid this issue. The initial health check is always done immediately.
- Ability to wait for the initial health check to complete: when we create an upstream list and immediately try to pick a healthy upstream from it, it, based on the initial scores, might return either no upstream or one of the down ones. This is because the health checks, which are done in a separate goroutine, didn't get the chance to complete yet. We can avoid this issue by waiting for the initial health check to be done before calling `.Pick()` + with using correct initial scores.